### PR TITLE
fix: typo in menuItemChosen function fixed and orders submitting

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {


### PR DESCRIPTION
# Order Form Submit
## What Was Done
1. typo in menuItemChosenFunction changed from item to order_item as it is expected by the api

**Issue:** https://github.com/Shift3/react-challenge-project/issues/14